### PR TITLE
Can configure multiple watch directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,28 @@ rtorrent_numwant: -1
 # ----- directory settings -----
 rtorrent_directory_download: ~/rtorrent/download
 rtorrent_directory_session: ~/rtorrent/.session
+
+# directory_watch can be a directory path (like the default value), a dict or
+# a list of dicts for multiple watch directories.
+# Example for one watch directory:
+#   rtorrent_directory_watch:
+#     path: ~/rtorrent/watch
+#     refresh_time: 10
+#     download: ~/rtorrent/download_complete
+# Example for multiple watch directories:
+#   rtorrent_directory_watch:
+#     - ~/rtorrent/watch
+#     - path: ~/rtorrent/watch1
+#       refresh_time: 30
+#     - path: ~/rtorrent/watch2
+#       download: ~/rtorrent/download_custom
+# When not set, refresh_time={{ rtorrent_global_refresh_time }} and
+# download={{ rtorrent_directory_download }}
 rtorrent_directory_watch: ~/rtorrent/watch
+
+# Move completed torrents to the download directory as set in their watch
+# directory
+rtorrent_move_when_complete: false
 
 # ----- network settings -----
 rtorrent_port_range: 49164-49164
@@ -56,8 +77,9 @@ rtorrent_dns_cache_timeout: 60
 rtorrent_xmlrpc_size_limit: 524288
 
 # ----- schedule settings -----
-rtorrent_schedule_watch_directory: "watch_directory,5,5,load_start={{ rtorrent_directory_watch }}/*.torrent"
-rtorrent_schedule_untied_directory: "untied_directory,5,5,stop_untied="
+# Set refresh time for untied_directory and watch directories
+rtorrent_global_refresh_time: 5
+rtorrent_schedule_untied_directory: "untied_directory,{{ rtorrent_global_refresh_time }},{{ rtorrent_global_refresh_time }},stop_untied="
 
 # ----- torrent settings -----
 rtorrent_check_hash: "no"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,28 @@ rtorrent_numwant: -1
 # ----- directory settings -----
 rtorrent_directory_download: ~/rtorrent/download
 rtorrent_directory_session: ~/rtorrent/.session
+
+# directory_watch can be a directory path (like the default value), a dict or
+# a list of dicts for multiple watch directories.
+# Example for one watch directory:
+#   rtorrent_directory_watch:
+#     path: ~/rtorrent/watch
+#     refresh_time: 10
+#     download: ~/rtorrent/download_complete
+# Example for multiple watch directories:
+#   rtorrent_directory_watch:
+#     - ~/rtorrent/watch
+#     - path: ~/rtorrent/watch1
+#       refresh_time: 30
+#     - path: ~/rtorrent/watch2
+#       download: ~/rtorrent/download_custom
+# When not set, refresh_time={{ rtorrent_global_refresh_time }} and
+# download={{ rtorrent_directory_download }}
 rtorrent_directory_watch: ~/rtorrent/watch
+
+# Move completed torrents to the download directory as set in their watch
+# directory
+rtorrent_move_when_complete: false
 
 # ----- network settings -----
 rtorrent_port_range: 49164-49164
@@ -31,8 +52,9 @@ rtorrent_dns_cache_timeout: 60
 rtorrent_xmlrpc_size_limit: 524288
 
 # ----- schedule settings -----
-rtorrent_schedule_watch_directory: watch_directory,5,5,load_start={{ rtorrent_directory_watch }}/*.torrent
-rtorrent_schedule_untied_directory: untied_directory,5,5,stop_untied=
+# Set refresh time for untied_directory and watch directories
+rtorrent_global_refresh_time: 5
+rtorrent_schedule_untied_directory: "untied_directory,{{ rtorrent_global_refresh_time }},{{ rtorrent_global_refresh_time }},stop_untied="
 
 # ----- torrent settings -----
 rtorrent_check_hash: "no"

--- a/templates/rtorrent.rc.j2
+++ b/templates/rtorrent.rc.j2
@@ -118,10 +118,29 @@ protocol.pex.set = {{ rtorrent_peer_exchange }}
 {{ v }};
 {% endfor %}
 
-# Watch a directory for new torrents, and stop those that have been
-# deleted.
-schedule = {{ rtorrent_schedule_watch_directory }}
+# Watch one or multiple directories for new torrents, and stop those that have
+# been deleted.
+{% if rtorrent_directory_watch is string or rtorrent_directory is mapping %}
+    {% set rtorrent_directory_watch = [rtorrent_directory_watch,] %}
+{% endif %}
+{% for watch_dir in rtorrent_directory_watch %}
+    {% if watch_dir is mapping %}
+        {% set watch_dir_path = watch_dir.path %}
+    {% else %}
+        {% set watch_dir_path = watch_dir %}
+    {% endif %}
+    schedule = {{ watch_dir_path }},{{ watch_dir.refresh_time|default(rtorrent_global_refresh_time) }},{{ watch_dir.refresh_time|default(rtorrent_global_refresh_time) }},"load_start={{ watch_dir_path }}/*.torrent,d.set_custom1={{ watch_dir.download|default(rtorrent_directory_download) }}"
+{% endfor %}
 schedule = {{ rtorrent_schedule_untied_directory }}
+
+# Move torrents on completion
+{% if rtorrent_move_when_complete %}
+system.method.insert=checkdirs1,simple,"not=\"$equal={d.get_custom1=,d.get_base_path=}\""
+system.method.insert=movecheck1,simple,"and={checkdirs1=,d.get_complete=,d.get_custom1=}"
+system.method.insert=movedir1,simple,"d.set_directory=$d.get_custom1=;execute=mv,-u,$d.get_base_path=,$d.get_custom1=;d.set_custom1=;d.stop=;d.start="
+system.method.set_key=event.download.hash_done,move_hashed1,"branch={$movecheck1=,movedir1=}"
+method.set_key=event.download.finished,move_complete,"branch={$movecheck1=,movedir1=}"
+{% endif %}
 
 # Whether to allocate disk space for a new torrent.
 system.file.allocate.set = {{ rtorrent_file_allocate }}


### PR DESCRIPTION
Hi,
I added the ability to setup multiple watch directories. This is compatible with the "old way" to setup a watch directory (for example `rtorrent_directory_wath: ~/rtorrent/watch`) or you can declare it with a dict or a list of string/dict.
It also allows to setup a download directory, them move complete torrents in another directory (`watch_dir.download`).